### PR TITLE
removing extra whitespace in dictionary keys in on() and off() methods

### DIFF
--- a/tplight.py
+++ b/tplight.py
@@ -120,9 +120,9 @@ class LB130(object):
         Set the bulb to an on state
         '''
         __bulb_on_off = 1
-        self.__update("{\"smartlife.iot.smartbulb.lightingservice\":{\"\
-                      transition_light_state\":{\"ignore_default\":1,\"\
-                      transition_period\":" +
+        self.__update("{\"smartlife.iot.smartbulb.lightingservice\":{\""
+                      "transition_light_state\":{\"ignore_default\":1,\""
+                      "transition_period\":" +
                       str(self.__transition_period) + ",\"on_off\":1}}}")
 
     def off(self):
@@ -130,9 +130,10 @@ class LB130(object):
         Set the bulb to an off state
         '''
         __bulb_on_off = 0
-        self.__update("{\"smartlife.iot.smartbulb.lightingservice\":{\"\
-                      transition_light_state\":{\"ignore_default\":1,\"transition_period\"\
-                      :" + str(self.__transition_period) + ",\"on_off\":0}}}")
+        self.__update("{\"smartlife.iot.smartbulb.lightingservice\":{\""
+                      "transition_light_state\":{\"ignore_default\":1,\"transition_period\""
+                      ":" + str(self.__transition_period) + ",\"on_off\":0}}}")
+
 
     def reboot(self):
         '''


### PR DESCRIPTION
This should fix #3 by removing some extra whitespace that was included into the dictionary keys `transition_light_state` and `transition_period`. However the problem that the lights can't turn on (#1) when they are off persists.