### PR TITLE
increasing buffer size and adjusting dictionary when light is off

### DIFF
--- a/tplight.py
+++ b/tplight.py
@@ -413,7 +413,7 @@ class LB130(object):
             data_received = False
             dec_data = ""
             while True:
-                data, addr = sock.recvfrom(2048)  # buffer size is 1024 bytes
+                data, addr = sock.recvfrom(2048)  # buffer size is 2048 bytes
                 dec_data += self.__decrypt(data, self.encryption_key)
                 if "}}}" in dec_data:  # end of sysinfo message
                     data_received = True
@@ -442,7 +442,7 @@ class LB130(object):
             data_received = False
             dec_data = ""
             while True:
-                data, addr = sock.recvfrom(2048)  # buffer size is 2048 bytes2
+                data, addr = sock.recvfrom(2048)  # buffer size is 2048 bytes
                 dec_data += self.__decrypt(data, self.encryption_key)
                 if "}}}" in dec_data:  # end of sysinfo message
                     data_received = True

--- a/tplight.py
+++ b/tplight.py
@@ -68,12 +68,17 @@ class LB130(object):
                 col1 = 'system'
                 col2 = 'get_sysinfo'
                 col3 = 'light_state'
+                col4 = 'dft_on_state'
                 self.__alias = data[col1][col2]['alias']
                 self.__on_off = int(data[col1][col2][col3]['on_off'])
-                self.__hue = int(data[col1][col2][col3]['hue'])
-                self.__saturation = int(data[col1][col2][col3]['saturation'])
-                self.__brightness = int(data[col1][col2][col3]['brightness'])
-                self.__color_temp = int(data[col1][col2][col3]['color_temp'])
+                if self.__on_off:
+                    state_dict = data[col1][col2][col3]
+                else:
+                    state_dict = data[col1][col2][col3][col4]
+                self.__hue = int(state_dict['hue'])
+                self.__saturation = int(state_dict['saturation'])
+                self.__brightness = int(state_dict['brightness'])
+                self.__color_temp = int(state_dict['color_temp'])
                 self.device_id = str(data[col1][col2]['deviceId'])
             except (RuntimeError, TypeError, ValueError) as exception:
                 raise Exception(exception)
@@ -408,8 +413,8 @@ class LB130(object):
             data_received = False
             dec_data = ""
             while True:
-                data, addr = sock.recvfrom(1024)  # buffer size is 1024 bytes
-                dec_data = self.__decrypt(data, self.encryption_key)
+                data, addr = sock.recvfrom(2048)  # buffer size is 1024 bytes
+                dec_data += self.__decrypt(data, self.encryption_key)
                 if "}}}" in dec_data:  # end of sysinfo message
                     data_received = True
                     break
@@ -437,8 +442,8 @@ class LB130(object):
             data_received = False
             dec_data = ""
             while True:
-                data, addr = sock.recvfrom(1024)  # buffer size is 1024 bytes
-                dec_data = self.__decrypt(data, self.encryption_key)
+                data, addr = sock.recvfrom(2048)  # buffer size is 2048 bytes2
+                dec_data += self.__decrypt(data, self.encryption_key)
                 if "}}}" in dec_data:  # end of sysinfo message
                     data_received = True
                     break


### PR DESCRIPTION
This should now also fix #1. I made two changes: The dictionary that comes back when querying the status is longer than 1024 bytes and it seems the light bulb only sends data once, so it was nescessary to increase the buffer size: 

https://github.com/briandorey/tp-link-LB130-Smart-Wi-Fi-Bulb/blob/6d53c3769a0807ab45d369b930ac8be474039ead/tplight.py#L445-L446

The other change was to distinguish in `__init__` between on and off state - in the off state the light attributes are in another sub dictionary with key `dft_on_state`:

https://github.com/briandorey/tp-link-LB130-Smart-Wi-Fi-Bulb/blob/a44c5f9b8c821d5e7cf6faca2977b0644cb71371/tplight.py#L71-L81

I hope these things are the same for all versions of LB130